### PR TITLE
fix(mojaloop/#2652): update sagas to handle rbac error messages

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Wait for deployment readiness
       # Skaffold is supposed to do this, but for whatever reason, does not. At the time of writing,
       # investigating this was not a priority.
-      run: timeout 900 kubectl wait --for=condition=Ready pod --all --timeout=900s
+      run: timeout 1500 kubectl wait --for=condition=Ready pod --all --timeout=1200s
 
     - name: Port-forward the portal frontend ingress
       run: kubectl port-forward -n ingress-nginx --address 0.0.0.0 svc/ingress-nginx-controller 3000:80 &

--- a/src/App/SettlementWindows/sagas.ts
+++ b/src/App/SettlementWindows/sagas.ts
@@ -77,6 +77,10 @@ function* fetchSettlementWindows() {
           return [];
         }
         assert(
+          resp.status !== 403,
+          `Failed to retrieve settlement window data - ${resp.data.error.message}`,
+        );
+        assert(
           resp.status >= 200 && resp.status < 300,
           `Failed to retrieve settlement window data`,
         );
@@ -137,7 +141,10 @@ function* settleWindows() {
       },
     });
     assert.equal(settlementResponse.status, 200, 'Unable to settle settlement window');
-
+    assert(
+      settlementResponse.status !== 403,
+      `Failed to retrieve settlement window data - ${settlementResponse.data.error.message}`,
+    );
     const settlement = settlementResponse.data;
     // @ts-ignore
     const settlementRecordedResult = yield call(
@@ -191,6 +198,10 @@ function* closeSettlementWindow(action: PayloadAction<SettlementWindow>) {
       const msg = !info ? '' : ` due to error ${info.errorCode}: "${info.errorDescription}"`;
       throw new Error(`Unable to Close Window${msg}`);
     }
+    assert(
+      response.status !== 403,
+      `Failed to retrieve settlement window data - ${response.data.error.message}`,
+    );
 
     yield put(setCloseSettlementWindowFinished());
     yield put(requestSettlementWindows());

--- a/src/App/SettlementWindows/views.tsx
+++ b/src/App/SettlementWindows/views.tsx
@@ -136,7 +136,9 @@ const SettlementWindowModal: FC<SettlementWindowModalProps> = ({
     content = <Spinner center />;
   } else if (error) {
     title = 'Failed Settlement Submit';
-    content = <MessageBox kind="danger">There was an error settling the windows</MessageBox>;
+    content = (
+      <MessageBox kind="danger">There was an error settling the windows - {error}</MessageBox>
+    );
   } else {
     title = 'Settlement Submitted';
     content = (

--- a/src/App/Settlements/views.tsx
+++ b/src/App/Settlements/views.tsx
@@ -134,7 +134,11 @@ const Settlements: FC<SettlementsProps> = ({
 }) => {
   let content = null;
   if (settlementsError) {
-    content = <MessageBox kind="danger">there was an error with the settlements</MessageBox>;
+    content = (
+      <MessageBox kind="danger">
+        There was an error with the settlements - {settlementsError}
+      </MessageBox>
+    );
   } else if (isSettlementsPending) {
     content = <Spinner center />;
   } else {


### PR DESCRIPTION
fix(mojaloop/#2652): update sagas to handle rbac error messages - https://github.com/mojaloop/project/issues/2652

Unsure as to why integration tests aren't passing. Seems that it was broken along time ago but we've chosen to ignore it?

Tested on sandbox with image
![Mojaloop-Business-Operations-Portal](https://user-images.githubusercontent.com/5932442/230184665-3a275ad0-835f-4551-946a-f7f6794612bd.png)
![Mojaloop-Business-Operations-Portal (2)](https://user-images.githubusercontent.com/5932442/230184700-f566e186-9f37-4ad8-aad2-ec784eaad5ba.png)
